### PR TITLE
Design a Token/Operator documentation API to allow for automatic user help docs

### DIFF
--- a/sept/balancer.py
+++ b/sept/balancer.py
@@ -15,12 +15,19 @@ class ParenthesisBalancer(object):
         self._root_locations = []
         self._currently_open_locations = []
         self._recently_closed_locations = []
+        self._single_opens = []
+        self._single_closes = []
         self._errors = []
 
     def execute(self):
         # msg = " {} ".format(msg)
         for index, curr_char in enumerate(self.template_str):
             prev_char, next_char = self._get_chars(curr_index=index)
+
+            if curr_char == START_TOK:
+                self._single_opens.append(index)
+            elif curr_char == CLOSE_TOK:
+                self._single_closes.append(index)
 
             if self._is_start_tok(curr_char, next_char):
                 # Might have a tok_start
@@ -42,10 +49,15 @@ class ParenthesisBalancer(object):
                     self.close_group(curr_index=index)
         if self._currently_open_locations:
             for open_location in self._currently_open_locations:
+                next_close = open_location
+                for close_index in reversed(self._single_closes):
+                    if close_index < open_location:
+                        break
+                    next_close = close_index
                 self._errors.append(
                     ClosingBalancingParenthesisError(
                         start_location=open_location,
-                        end_location=len(self.template_str) - 1,
+                        end_location=next_close,
                         missing_token=CLOSE_TOK + CLOSE_TOK,
                         substr=self.template_str[open_location:],
                     )
@@ -81,12 +93,19 @@ class ParenthesisBalancer(object):
             if self._recently_closed_locations:
                 last_closed = self._recently_closed_locations[-1]
 
+            last_open = last_closed + 2
+            for open_index in reversed(self._single_opens):
+                if open_index < last_closed:
+                    break
+                last_open = open_index
+
+            end_index = curr_index + 1
             self._errors.append(
                 OpeningBalancingParenthesisError(
-                    start_location=last_closed + 1,
-                    end_location=curr_index,
+                    start_location=last_open,
+                    end_location=end_index,
                     missing_token=START_TOK + START_TOK,
-                    substr=self.template_str,
+                    substr=self.template_str[last_open:end_index + 1],
                 )
             )
             return

--- a/sept/balancer.py
+++ b/sept/balancer.py
@@ -105,7 +105,7 @@ class ParenthesisBalancer(object):
                     start_location=last_open,
                     end_location=end_index,
                     missing_token=START_TOK + START_TOK,
-                    substr=self.template_str[last_open:end_index + 1],
+                    substr=self.template_str[last_open : end_index + 1],
                 )
             )
             return

--- a/sept/builtin/operators/__init__.py
+++ b/sept/builtin/operators/__init__.py
@@ -2,6 +2,7 @@ from .lower import LowerOperator
 from .upper import UpperOperator
 from .substr import SubStringOperator
 from .replace import ReplaceOperator
+from .pad import PadOperator
 from .null import NullOperator
 
 ALL_OPERATORS = [
@@ -10,4 +11,5 @@ ALL_OPERATORS = [
     SubStringOperator,
     NullOperator,
     ReplaceOperator,
+    PadOperator,
 ]

--- a/sept/builtin/operators/lower.py
+++ b/sept/builtin/operators/lower.py
@@ -10,6 +10,7 @@ class LowerOperator(Operator):
     <br>&emsp;<code>"alex" &nbsp;&nbsp;-> "alex"</code>
     <br>&emsp;<code>"ALEX11" -> "alex11"</code>
     """
+
     name = "lower"
 
     def is_invalid(self, token_value):

--- a/sept/builtin/operators/lower.py
+++ b/sept/builtin/operators/lower.py
@@ -2,6 +2,14 @@ from sept.operator import Operator
 
 
 class LowerOperator(Operator):
+    """
+    The <code>lower</code> Operator will convert your Token to lowercase.
+    <br>
+    <br>Examples:
+    <br>&emsp;<code>"Alex" &nbsp;&nbsp;-> "alex"</code>
+    <br>&emsp;<code>"alex" &nbsp;&nbsp;-> "alex"</code>
+    <br>&emsp;<code>"ALEX11" -> "alex11"</code>
+    """
     name = "lower"
 
     def is_invalid(self, token_value):

--- a/sept/builtin/operators/null.py
+++ b/sept/builtin/operators/null.py
@@ -10,6 +10,7 @@ class NullOperator(Operator):
     <br>&emsp;<code>"alex"  &nbsp; &nbsp;-> "alex"</code>
     <br>&emsp;<code>"ALEX11" -> "ALEX11"</code>
     """
+
     name = "NULL"
     _private = True
 

--- a/sept/builtin/operators/null.py
+++ b/sept/builtin/operators/null.py
@@ -2,7 +2,16 @@ from sept.operator import Operator
 
 
 class NullOperator(Operator):
+    """
+    The <code>null</code> Operator will do nothing to you Token.
+    <br>
+    <br>Examples:
+    <br>&emsp;<code>"Alex"  &nbsp; &nbsp;-> "Alex"</code>
+    <br>&emsp;<code>"alex"  &nbsp; &nbsp;-> "alex"</code>
+    <br>&emsp;<code>"ALEX11" -> "ALEX11"</code>
+    """
     name = "NULL"
+    _private = True
 
     def is_invalid(self, token_value):
         return None

--- a/sept/builtin/operators/pad.py
+++ b/sept/builtin/operators/pad.py
@@ -11,6 +11,7 @@ class PadOperator(Operator):
     <br>&emsp;<code>{{pad[1,X]:name}} -> "1"</code>
     <br>&emsp;<code>{{pad[4,0]:name}} -> "0001"</code>
     """
+
     name = "pad"
 
     def is_invalid(self, token_value):
@@ -38,8 +39,7 @@ class PadOperator(Operator):
 
         try:
             template_msg = "{{:{char}>{count}}}".format(
-                char=padding_char,
-                count=padding_count
+                char=padding_char, count=padding_count
             )
             return template_msg.format(input_data)
         except Exception:

--- a/sept/builtin/operators/pad.py
+++ b/sept/builtin/operators/pad.py
@@ -1,0 +1,46 @@
+from sept.operator import Operator
+
+
+class PadOperator(Operator):
+    """
+    The <code>pad</code> Operator allows you to pad your token with characters.
+    <br>This Operator supports the arguments a number of padding and then any single character.
+    <br>
+    <br>Examples (name = "1"):
+    <br>&emsp;<code>{{pad[4,X]:name}} -> "XXX1"</code>
+    <br>&emsp;<code>{{pad[1,X]:name}} -> "1"</code>
+    <br>&emsp;<code>{{pad[4,0]:name}} -> "0001"</code>
+    """
+    name = "pad"
+
+    def is_invalid(self, token_value):
+        args = self._args
+        if not args or len(args) != 2:
+            return (
+                "Invalid argument values passed to {name}. We expect two "
+                "arguments that are text values.".format(name=self.name)
+            )
+        try:
+            int(self._args[0])
+        except (TypeError, ValueError):
+            # Could not cast to int
+            return "The first input value passed should be a number."
+        if len(self._args[1]) > 1:
+            return "The padding character as the second input value needs to be a single character/"
+        return None
+
+    def execute(self, input_data):
+        padding_count, padding_char = self._args
+        try:
+            padding_count = int(padding_count)
+        except (TypeError, ValueError):
+            return None
+
+        try:
+            template_msg = "{{:{char}>{count}}}".format(
+                char=padding_char,
+                count=padding_count
+            )
+            return template_msg.format(input_data)
+        except Exception:
+            return None

--- a/sept/builtin/operators/replace.py
+++ b/sept/builtin/operators/replace.py
@@ -5,7 +5,18 @@ from sept.operator import Operator
 
 
 class ReplaceOperator(Operator):
+    """
+    The <code>replace</code> Operator allows you to find and replace characters in your Token.
+    <br>
+    <br>Examples (name = "alex"):
+    <br>&emsp;<code>{{replace[ex,an]:name}}&nbsp;&nbsp;   -> "alan"</code>
+    <br>&emsp;<code>{{replace[kite,dog:name}} -> "alex"</code>
+    """
     name = "replace"
+    args = [
+        {"name": "Find String", "description": "The characters that you want to search for and replace", "required": True},
+        {"name": "Replace String", "description": "The characters that you want to replace the \"Find Striing\" with.", "required": True},
+    ]
     SPACE = "\\s"
     DATA_TYPES = (six.text_type, six.binary_type)
     keywords = {

--- a/sept/builtin/operators/replace.py
+++ b/sept/builtin/operators/replace.py
@@ -12,10 +12,19 @@ class ReplaceOperator(Operator):
     <br>&emsp;<code>{{replace[ex,an]:name}}&nbsp;&nbsp;   -> "alan"</code>
     <br>&emsp;<code>{{replace[kite,dog:name}} -> "alex"</code>
     """
+
     name = "replace"
     args = [
-        {"name": "Find String", "description": "The characters that you want to search for and replace", "required": True},
-        {"name": "Replace String", "description": "The characters that you want to replace the \"Find String\" with.", "required": True},
+        {
+            "name": "Find String",
+            "description": "The characters that you want to search for and replace",
+            "required": True,
+        },
+        {
+            "name": "Replace String",
+            "description": 'The characters that you want to replace the "Find String" with.',
+            "required": True,
+        },
     ]
     SPACE = "\\s"
     DATA_TYPES = (six.text_type, six.binary_type)

--- a/sept/builtin/operators/replace.py
+++ b/sept/builtin/operators/replace.py
@@ -15,7 +15,7 @@ class ReplaceOperator(Operator):
     name = "replace"
     args = [
         {"name": "Find String", "description": "The characters that you want to search for and replace", "required": True},
-        {"name": "Replace String", "description": "The characters that you want to replace the \"Find Striing\" with.", "required": True},
+        {"name": "Replace String", "description": "The characters that you want to replace the \"Find String\" with.", "required": True},
     ]
     SPACE = "\\s"
     DATA_TYPES = (six.text_type, six.binary_type)

--- a/sept/builtin/operators/substr.py
+++ b/sept/builtin/operators/substr.py
@@ -5,7 +5,21 @@ from sept.operator import Operator
 
 
 class SubStringOperator(Operator):
+    """
+    The <code>substr</code> Operator allows you to return a subset of the Token.
+    <br>This Operator supports the arguments "start" and "end" as well as numerical indexes from zero.
+    <br>
+    <br>Examples (name = "alex"):
+    <br>&emsp;<code>{{substr[start,2]:name}} -> "al"</code>
+    <br>&emsp;<code>{{substr[0,2]:name}} &nbsp; &nbsp;&nbsp;&nbsp;-> "al"</code>
+    <br>&emsp;<code>{{substr[0,end]:name}} &nbsp;&nbsp;-> "alex"</code>
+    <br>&emsp;<code>{{substr[1,3]:name}} &nbsp; &nbsp;&nbsp;&nbsp;-> "le"</code>
+    """
     name = "substr"
+    args = [
+        {"name": "Start Location", "description": "The location we want to start our subset from. This supports numbers as well as \"end\" and \"start\"", "required": True},
+        {"name": "End Location", "description": "The location we want to end our subset at. This supports numbers as well as \"end\" and \"start\"", "required": False},
+    ]
     START_KEY = "start"
     END_KEY = "end"
     DATA_TYPES = (six.text_type, six.binary_type)

--- a/sept/builtin/operators/substr.py
+++ b/sept/builtin/operators/substr.py
@@ -15,10 +15,19 @@ class SubStringOperator(Operator):
     <br>&emsp;<code>{{substr[0,end]:name}} &nbsp;&nbsp;-> "alex"</code>
     <br>&emsp;<code>{{substr[1,3]:name}} &nbsp; &nbsp;&nbsp;&nbsp;-> "le"</code>
     """
+
     name = "substr"
     args = [
-        {"name": "Start Location", "description": "The location we want to start our subset from. This supports numbers as well as \"end\" and \"start\"", "required": True},
-        {"name": "End Location", "description": "The location we want to end our subset at. This supports numbers as well as \"end\" and \"start\"", "required": False},
+        {
+            "name": "Start Location",
+            "description": 'The location we want to start our subset from. This supports numbers as well as "end" and "start"',
+            "required": True,
+        },
+        {
+            "name": "End Location",
+            "description": 'The location we want to end our subset at. This supports numbers as well as "end" and "start"',
+            "required": False,
+        },
     ]
     START_KEY = "start"
     END_KEY = "end"
@@ -49,11 +58,8 @@ class SubStringOperator(Operator):
                 return (
                     "Invalid input value passed to {name}. "
                     "We expect the first argument to be a number or either "
-                    "\"start\" or \"end\" values. "
-                    "{value} was passed instead.".format(
-                        name=self.name,
-                        value=start
-                    )
+                    '"start" or "end" values. '
+                    "{value} was passed instead.".format(name=self.name, value=start)
                 )
 
         if end not in self.keywords:
@@ -63,11 +69,8 @@ class SubStringOperator(Operator):
                 return (
                     "Invalid input value passed to {name}. "
                     "We expect the second argument to be a number or either "
-                    "\"start\" or \"end\" values. "
-                    "{value} was passed instead.".format(
-                        name=self.name,
-                        value=end
-                    )
+                    '"start" or "end" values. '
+                    "{value} was passed instead.".format(name=self.name, value=end)
                 )
         if isinstance(token_value, self.DATA_TYPES):
             # Is valid

--- a/sept/builtin/operators/substr.py
+++ b/sept/builtin/operators/substr.py
@@ -36,6 +36,39 @@ class SubStringOperator(Operator):
                 "or two arguments that are either a number or either "
                 '"start" or "end" text values.'.format(name=self.name)
             )
+        if len(args) == 1:
+            start = args
+            end = self.END_KEY
+        else:
+            start, end = args
+
+        if start not in self.keywords:
+            try:
+                int(start)
+            except ValueError:
+                return (
+                    "Invalid input value passed to {name}. "
+                    "We expect the first argument to be a number or either "
+                    "\"start\" or \"end\" values. "
+                    "{value} was passed instead.".format(
+                        name=self.name,
+                        value=start
+                    )
+                )
+
+        if end not in self.keywords:
+            try:
+                int(end)
+            except ValueError:
+                return (
+                    "Invalid input value passed to {name}. "
+                    "We expect the second argument to be a number or either "
+                    "\"start\" or \"end\" values. "
+                    "{value} was passed instead.".format(
+                        name=self.name,
+                        value=end
+                    )
+                )
         if isinstance(token_value, self.DATA_TYPES):
             # Is valid
             return None

--- a/sept/builtin/operators/upper.py
+++ b/sept/builtin/operators/upper.py
@@ -10,6 +10,7 @@ class UpperOperator(Operator):
     <br>&emsp;<code>"alex" &nbsp;&nbsp;-> "ALEX"</code>
     <br>&emsp;<code>"alex11" -> "ALEX11"</code>
     """
+
     name = "upper"
 
     def is_invalid(self, token_value):

--- a/sept/builtin/operators/upper.py
+++ b/sept/builtin/operators/upper.py
@@ -2,6 +2,14 @@ from sept.operator import Operator
 
 
 class UpperOperator(Operator):
+    """
+    The <code>upper</code> Operator will convert your Token to uppercase.
+    <br>
+    <br>Examples:
+    <br>&emsp;<code>"Alex" &nbsp;&nbsp;-> "ALEX"</code>
+    <br>&emsp;<code>"alex" &nbsp;&nbsp;-> "ALEX"</code>
+    <br>&emsp;<code>"alex11" -> "ALEX11"</code>
+    """
     name = "upper"
 
     def is_invalid(self, token_value):

--- a/sept/documentation.py
+++ b/sept/documentation.py
@@ -1,12 +1,23 @@
 
 
 class DocumentationGenerator(object):
+    _divider = "<hr><br>"
+
+    _overall_token_html_template = """
+    <h1>Token Documentation</h1>
+    <br>
+    {tokens}
+    """
+    _individual_token_html_template = """
+    <h2><code>{name}</code> Token</h2>
+    {token_doc}"""
+
+    # Operator templates
     _overall_operator_html_template = """
     <h1>Operator Documentation</h1>
     <br>
     {operators}
     """
-    _operator_divider = "<hr><br>"
     _operator_args_html_template = """<h4>&emsp;<code>Operator Inputs</code></h4>
     {args}
     """
@@ -23,6 +34,21 @@ class DocumentationGenerator(object):
         super(DocumentationGenerator, self).__init__()
         self.token_manager = token_manager
         self.operator_manager = operator_manager
+
+    def generate_token_documentation(self, token_manager=None):
+        token_manager = token_manager or self.token_manager
+
+        template = self._overall_token_html_template
+        tokens_text = []
+        for token in token_manager.tokens:
+            token_text = self._individual_token_html_template.format(
+                name=token.name,
+                token_doc=token.__doc__,
+            )
+            tokens_text.append(token_text)
+        return template.format(
+            tokens=self._divider.join(tokens_text)
+        )
 
     def generate_operator_documentation(self, operator_manager=None):
         operator_manager = operator_manager or self.operator_manager
@@ -54,5 +80,5 @@ class DocumentationGenerator(object):
             )
             operators_text.append(operator_text)
         return template.format(
-            operators=self._operator_divider.join(operators_text)
+            operators=self._divider.join(operators_text)
         )

--- a/sept/documentation.py
+++ b/sept/documentation.py
@@ -2,10 +2,10 @@
 
 class DocumentationGenerator(object):
     _divider = "<hr><br>"
+    _token_divider = "<hr>"
 
     _overall_token_html_template = """
     <h1>Token Documentation</h1>
-    <br>
     {tokens}
     """
     _individual_token_html_template = """
@@ -47,7 +47,7 @@ class DocumentationGenerator(object):
             )
             tokens_text.append(token_text)
         return template.format(
-            tokens=self._divider.join(tokens_text)
+            tokens=self._token_divider.join(tokens_text)
         )
 
     def generate_operator_documentation(self, operator_manager=None):

--- a/sept/documentation.py
+++ b/sept/documentation.py
@@ -1,5 +1,3 @@
-
-
 class DocumentationGenerator(object):
     _divider = "<hr><br>"
     _token_divider = "<hr>"
@@ -46,9 +44,7 @@ class DocumentationGenerator(object):
                 token_doc=token.__doc__,
             )
             tokens_text.append(token_text)
-        return template.format(
-            tokens=self._token_divider.join(tokens_text)
-        )
+        return template.format(tokens=self._token_divider.join(tokens_text))
 
     def generate_operator_documentation(self, operator_manager=None):
         operator_manager = operator_manager or self.operator_manager
@@ -79,6 +75,4 @@ class DocumentationGenerator(object):
                 operator_doc=operator.__doc__,
             )
             operators_text.append(operator_text)
-        return template.format(
-            operators=self._divider.join(operators_text)
-        )
+        return template.format(operators=self._divider.join(operators_text))

--- a/sept/documentation.py
+++ b/sept/documentation.py
@@ -1,0 +1,58 @@
+
+
+class DocumentationGenerator(object):
+    _overall_operator_html_template = """
+    <h1>Operator Documentation</h1>
+    <br>
+    {operators}
+    """
+    _operator_divider = "<hr><br>"
+    _operator_args_html_template = """<h4>&emsp;<code>Operator Inputs</code></h4>
+    {args}
+    """
+    _operator_arg_html_template = """<h5>
+    &emsp;&emsp;<u>{name}</u>: {description}
+    <br>&emsp;&emsp;&emsp;&emsp;<code>Required: {required}</code>
+    </h5>"""
+    _individual_operator_html_template = """
+    <h2><code>{name}</code> Operator</h2>
+    {operator_args}
+    <br>{operator_doc}"""
+
+    def __init__(self, token_manager, operator_manager):
+        super(DocumentationGenerator, self).__init__()
+        self.token_manager = token_manager
+        self.operator_manager = operator_manager
+
+    def generate_operator_documentation(self, operator_manager=None):
+        operator_manager = operator_manager or self.operator_manager
+
+        template = self._overall_operator_html_template
+        operators_text = []
+        for operator in operator_manager.operators:
+            operator_args = []
+            for arg in operator.args:
+                arg_name = arg.get("name", "unnamed")
+                arg_description = arg.get("description", "")
+                arg_required = arg.get("required", False)
+                arg_text = self._operator_arg_html_template.format(
+                    name=arg_name,
+                    description=arg_description,
+                    required=arg_required,
+                )
+                operator_args.append(arg_text)
+            operator_args_text = ""
+            if operator_args:
+                operator_args_text = self._operator_args_html_template.format(
+                    args="".join(operator_args)
+                )
+
+            operator_text = self._individual_operator_html_template.format(
+                name=operator.name,
+                operator_args=operator_args_text,
+                operator_doc=operator.__doc__,
+            )
+            operators_text.append(operator_text)
+        return template.format(
+            operators=self._operator_divider.join(operators_text)
+        )

--- a/sept/errors.py
+++ b/sept/errors.py
@@ -19,7 +19,9 @@ class LocationAwareSeptError(SeptError):
 
 class ParsingError(LocationAwareSeptError):
     def __init__(self, location, message, length=0):
-        super(ParsingError, self).__init__(location=location, message=message, length=length)
+        super(ParsingError, self).__init__(
+            location=location, message=message, length=length
+        )
 
 
 class MultipleParsingError(ParsingError):
@@ -31,7 +33,7 @@ class MultipleParsingError(ParsingError):
         super(MultipleParsingError, self).__init__(
             location=location,
             length=length,
-            message="\n".join(str(error) for error in errors)
+            message="\n".join(str(error) for error in errors),
         )
         self.errors = errors
 
@@ -76,7 +78,7 @@ class BalancingParenthesisError(ParsingError):
         super(BalancingParenthesisError, self).__init__(
             location=start_location,
             length=end_location - start_location + 1,
-            message=message
+            message=message,
         )
 
 
@@ -97,7 +99,7 @@ class MultipleBalancingError(ParsingError):
         super(MultipleBalancingError, self).__init__(
             location=location,
             length=length,
-            message="\n".join(str(error) for error in errors)
+            message="\n".join(str(error) for error in errors),
         )
         self.errors = errors
 

--- a/sept/errors.py
+++ b/sept/errors.py
@@ -1,7 +1,5 @@
 class SeptError(RuntimeError):
-    def __init__(self, location, message):
-        super(SeptError, self).__init__(message)
-        self.location = location
+    pass
 
 
 class TokenNotFoundError(SeptError):
@@ -12,9 +10,16 @@ class OperatorError(SeptError):
     pass
 
 
-class ParsingError(SeptError):
-    def __init__(self, location, message):
-        super(ParsingError, self).__init__(location, message)
+class LocationAwareSeptError(SeptError):
+    def __init__(self, location, message, length=0):
+        super(SeptError, self).__init__(message)
+        self.location = location
+        self.length = length
+
+
+class ParsingError(LocationAwareSeptError):
+    def __init__(self, location, message, length=0):
+        super(ParsingError, self).__init__(location=location, message=message, length=length)
 
 
 class MultipleParsingError(ParsingError):
@@ -22,8 +27,10 @@ class MultipleParsingError(ParsingError):
         location = -1
         if errors:
             location = errors[0].location
+        length = max([e.location + e.length for e in errors])
         super(MultipleParsingError, self).__init__(
             location=location,
+            length=length,
             message="\n".join(str(error) for error in errors)
         )
         self.errors = errors
@@ -49,6 +56,7 @@ class InvalidCharacterParsingError(ParsingError):
 
         super(InvalidCharacterParsingError, self).__init__(
             location=self.start_col,
+            length=self.end_col - self.start_col,
             message=msg,
         )
 
@@ -67,6 +75,7 @@ class BalancingParenthesisError(ParsingError):
 
         super(BalancingParenthesisError, self).__init__(
             location=start_location,
+            length=end_location - start_location + 1,
             message=message
         )
 
@@ -84,8 +93,10 @@ class MultipleBalancingError(ParsingError):
         location = -1
         if errors:
             location = errors[0].location
+        length = max([e.location + e.length for e in errors])
         super(MultipleBalancingError, self).__init__(
             location=location,
+            length=length,
             message="\n".join(str(error) for error in errors)
         )
         self.errors = errors

--- a/sept/errors.py
+++ b/sept/errors.py
@@ -1,5 +1,7 @@
 class SeptError(RuntimeError):
-    pass
+    def __init__(self, location, message):
+        super(SeptError, self).__init__(message)
+        self.location = location
 
 
 class TokenNotFoundError(SeptError):
@@ -11,14 +13,18 @@ class OperatorError(SeptError):
 
 
 class ParsingError(SeptError):
-    def __init__(self, message):
-        super(ParsingError, self).__init__(message)
+    def __init__(self, location, message):
+        super(ParsingError, self).__init__(location, message)
 
 
 class MultipleParsingError(ParsingError):
     def __init__(self, errors):
+        location = -1
+        if errors:
+            location = errors[0].location
         super(MultipleParsingError, self).__init__(
-            "\n".join(str(error) for error in errors)
+            location=location,
+            message="\n".join(str(error) for error in errors)
         )
         self.errors = errors
 
@@ -42,6 +48,7 @@ class InvalidCharacterParsingError(ParsingError):
         )
 
         super(InvalidCharacterParsingError, self).__init__(
+            location=self.start_col,
             message=msg,
         )
 
@@ -58,8 +65,10 @@ class BalancingParenthesisError(ParsingError):
             )
         )
 
-        super(BalancingParenthesisError, self).__init__(message)
-        self.location = start_location
+        super(BalancingParenthesisError, self).__init__(
+            location=start_location,
+            message=message
+        )
 
 
 class OpeningBalancingParenthesisError(BalancingParenthesisError):
@@ -72,8 +81,12 @@ class ClosingBalancingParenthesisError(BalancingParenthesisError):
 
 class MultipleBalancingError(ParsingError):
     def __init__(self, errors):
+        location = -1
+        if errors:
+            location = errors[0].location
         super(MultipleBalancingError, self).__init__(
-            "\n".join(str(error) for error in errors)
+            location=location,
+            message="\n".join(str(error) for error in errors)
         )
         self.errors = errors
 

--- a/sept/operator.py
+++ b/sept/operator.py
@@ -8,6 +8,7 @@ class Operator(object):
 
     If you wanted to bold your text, you could just do <b>this!</b>
     """
+
     name = NotImplementedError
     args = [
         # The args class object is used as an argspec for your Operator

--- a/sept/operator.py
+++ b/sept/operator.py
@@ -1,5 +1,26 @@
 class Operator(object):
+    """
+    The docstring of your Operator is used as the documentation for your
+        Operator.
+    You should include any freeform text that you would like as well as some
+        examples of how your Operator works.
+    This docstring should be treated as html code.
+
+    If you wanted to bold your text, you could just do <b>this!</b>
+    """
     name = NotImplementedError
+    args = [
+        # The args class object is used as an argspec for your Operator
+        #   `args` should be a list of dict[name, description, required].
+        # eg:
+        #   args = [
+        #       {"name": "myarg1", "description": "This arg gets used for something", "required": True},
+        #       {"name": "myarg2", "description": "This is an extra arg, it's optional", "required": False},
+        #   ]
+    ]
+
+    # Internal...Ignore this
+    _private = False
 
     def __init__(self, args=None):
         super(Operator, self).__init__()

--- a/sept/operator_manager.py
+++ b/sept/operator_manager.py
@@ -36,10 +36,11 @@ class OperatorManager(object):
                 )
             self._cache[custom_operator.name] = custom_operator()
 
-    def getOperator(self, operator_name, args=None):
+    def getOperator(self, operator_name, args=None, token_offset=-1):
         if operator_name in self._cache:
             operator_klass = self._cache[operator_name]
             return operator_klass.create(args)
         raise OperatorNotFoundError(
-            "Could not find an Operator with the name {}".format(operator_name)
+            location=token_offset,
+            message="Could not find an Operator with the name {}".format(operator_name)
         )

--- a/sept/operator_manager.py
+++ b/sept/operator_manager.py
@@ -15,11 +15,8 @@ class OperatorManager(object):
     def operators(self):
         # Don't include the NULL operator
         return sorted(
-            filter(
-                lambda op: op._private is False,
-                self._cache.values()
-            ),
-            key=lambda op: op.name
+            filter(lambda op: op._private is False, self._cache.values()),
+            key=lambda op: op.name,
         )
 
     def add_custom_operators(self, custom_operators, dont_overwrite=True):

--- a/sept/operator_manager.py
+++ b/sept/operator_manager.py
@@ -36,11 +36,10 @@ class OperatorManager(object):
                 )
             self._cache[custom_operator.name] = custom_operator()
 
-    def getOperator(self, operator_name, args=None, token_offset=-1):
+    def getOperator(self, operator_name, args=None):
         if operator_name in self._cache:
             operator_klass = self._cache[operator_name]
             return operator_klass.create(args)
         raise OperatorNotFoundError(
-            location=token_offset,
-            message="Could not find an Operator with the name {}".format(operator_name)
+            "Could not find an Operator with the name {}".format(operator_name)
         )

--- a/sept/operator_manager.py
+++ b/sept/operator_manager.py
@@ -11,6 +11,17 @@ class OperatorManager(object):
         for operator_klass in ALL_OPERATORS:
             self._cache[operator_klass.name] = operator_klass
 
+    @property
+    def operators(self):
+        # Don't include the NULL operator
+        return sorted(
+            filter(
+                lambda op: op._private is False,
+                self._cache.values()
+            ),
+            key=lambda op: op.name
+        )
+
     def add_custom_operators(self, custom_operators, dont_overwrite=True):
         for custom_operator in custom_operators:
             if custom_operator.name in self._cache and dont_overwrite:

--- a/sept/parser.py
+++ b/sept/parser.py
@@ -1,5 +1,6 @@
 from sept.token_manager import TokenManager
 from sept.operator_manager import OperatorManager
+from sept.documentation import DocumentationGenerator
 from sept.template import Template
 
 
@@ -14,6 +15,17 @@ class PathTemplateParser(object):
         self._operator_manager = OperatorManager()
         if additional_operators:
             self._operator_manager.add_custom_operators(additional_operators)
+
+        self._documentation_generation = DocumentationGenerator(
+            token_manager=self._token_manager,
+            operator_manager=self._operator_manager,
+        )
+
+    def operator_documentation(self):
+        return self._documentation_generation.generate_operator_documentation()
+
+    def token_documentation(self):
+        return self._documentation_generation.generate_token_documentation()
 
     def parse(self, template, data):
         if not isinstance(template, Template):

--- a/sept/template.py
+++ b/sept/template.py
@@ -1,6 +1,13 @@
 from sept.template_tokenizer import Tokenizer
 from sept.balancer import ParenthesisBalancer
-from sept.errors import SeptError, ParsingError, MultipleBalancingError, OperatorNotFoundError, TokenNotFoundError, InvalidOperatorInputDataError
+from sept.errors import (
+    SeptError,
+    ParsingError,
+    MultipleBalancingError,
+    OperatorNotFoundError,
+    TokenNotFoundError,
+    InvalidOperatorInputDataError,
+)
 
 
 class _RawTokenExpression(object):
@@ -156,11 +163,7 @@ class Template(object):
             try:
                 transformed = resolved_token.execute(data)
             except InvalidOperatorInputDataError as err:
-                raise ParsingError(
-                    location=start,
-                    length=end - start,
-                    message=str(err)
-                )
+                raise ParsingError(location=start, length=end - start, message=str(err))
             result_str = before + transformed + after
             offset += len(transformed) - len(target)
 

--- a/sept/template.py
+++ b/sept/template.py
@@ -1,6 +1,6 @@
 from sept.template_tokenizer import Tokenizer
 from sept.balancer import ParenthesisBalancer
-from sept.errors import ParsingError, MultipleBalancingError
+from sept.errors import SeptError, ParsingError, MultipleBalancingError, OperatorNotFoundError, TokenNotFoundError, InvalidOperatorInputDataError
 
 
 class _RawTokenExpression(object):
@@ -30,7 +30,14 @@ class Template(object):
             args = None
             if match.Args:
                 args = match.Args
-            _Operator = omanager.getOperator(match.Operator, args=args)
+            try:
+                _Operator = omanager.getOperator(match.Operator, args=args)
+            except OperatorNotFoundError as err:
+                raise ParsingError(
+                    location=match.start + offset,
+                    length=match.end - match.start,
+                    message=str(err),
+                )
         if match.child:
             resolved_token = cls._gather_match(
                 match=match.child,
@@ -38,23 +45,37 @@ class Template(object):
                 omanager=omanager,
                 default_fallback=default_fallback,
             )
-            resolved_token = tmanager.bind_token(
-                token=resolved_token,
-                operator=_Operator,
-                tok_start=match.start + offset,
-                tok_end=match.end + offset,
-                tok_original_string=match.original_str,
-                default_fallback=default_fallback,
-            )
+            try:
+                resolved_token = tmanager.bind_token(
+                    token=resolved_token,
+                    operator=_Operator,
+                    tok_start=match.start + offset,
+                    tok_end=match.end + offset,
+                    tok_original_string=match.original_str,
+                    default_fallback=default_fallback,
+                )
+            except TokenNotFoundError as err:
+                raise ParsingError(
+                    location=match.start + offset,
+                    length=match.end - match.start,
+                    message=str(err),
+                )
         elif match.Token:
-            resolved_token = tmanager.bind_token(
-                token=match.Token,
-                operator=_Operator,
-                tok_start=match.start + offset,
-                tok_end=match.end + offset,
-                tok_original_string=match.original_str,
-                default_fallback=default_fallback,
-            )
+            try:
+                resolved_token = tmanager.bind_token(
+                    token=match.Token,
+                    operator=_Operator,
+                    tok_start=match.start + offset,
+                    tok_end=match.end + offset,
+                    tok_original_string=match.original_str,
+                    default_fallback=default_fallback,
+                )
+            except TokenNotFoundError as err:
+                raise ParsingError(
+                    location=match.start + offset,
+                    length=match.end - match.start,
+                    message=str(err),
+                )
         else:
             # raise ParsingError("Found Operator without corresponding token.")
             # TODO: Add location in error
@@ -73,7 +94,7 @@ class Template(object):
                 expressions.append(_expr)
             except IndexError:
                 # Unclear how we got here, probably a bug in balancer
-                raise ParsingError("Error extracting Token Expressions")
+                raise SeptError("Error extracting Token Expressions")
         if errors:
             raise MultipleBalancingError(errors)
         return expressions
@@ -132,7 +153,14 @@ class Template(object):
                 result_str[start + offset : end + offset],
                 result_str[end + offset :],
             )
-            transformed = resolved_token.execute(data)
+            try:
+                transformed = resolved_token.execute(data)
+            except InvalidOperatorInputDataError as err:
+                raise ParsingError(
+                    location=start,
+                    length=end - start,
+                    message=str(err)
+                )
             result_str = before + transformed + after
             offset += len(transformed) - len(target)
 

--- a/sept/token.py
+++ b/sept/token.py
@@ -31,6 +31,8 @@ class ResolvedToken(object):
 
     def execute(self, version_data):
         source_data = self.raw_token.getValue(version_data)
+        if source_data is None:
+            return self.original_string
         transformed_data = source_data
 
         previous_operator = None
@@ -44,7 +46,8 @@ class ResolvedToken(object):
                     "maybe the error originated there?"
                 )
                 raise InvalidOperatorInputDataError(
-                    error.format(
+                    location=self.start,
+                    message=error.format(
                         opname=operator.name,
                         errmsg=is_invalid_data,
                         prevop=previous_operator,

--- a/sept/token.py
+++ b/sept/token.py
@@ -2,6 +2,9 @@ from sept.errors import InvalidOperatorInputDataError
 
 
 class Token(object):
+    """
+    The docstring of your Token will be used as the documentation help message.
+    """
     name = NotImplementedError
 
     def getValue(self, data):

--- a/sept/token.py
+++ b/sept/token.py
@@ -46,8 +46,7 @@ class ResolvedToken(object):
                     "maybe the error originated there?"
                 )
                 raise InvalidOperatorInputDataError(
-                    location=self.start,
-                    message=error.format(
+                    error.format(
                         opname=operator.name,
                         errmsg=is_invalid_data,
                         prevop=previous_operator,

--- a/sept/token.py
+++ b/sept/token.py
@@ -5,6 +5,7 @@ class Token(object):
     """
     The docstring of your Token will be used as the documentation help message.
     """
+
     name = NotImplementedError
 
     def getValue(self, data):

--- a/sept/token_manager.py
+++ b/sept/token_manager.py
@@ -14,6 +14,14 @@ class TokenManager(object):
             token_name = token_klass.name.lower()
             self._cache[token_name] = token_klass()
 
+    @property
+    def tokens(self):
+        # Don't include the NULL operator
+        return sorted(
+            self._cache.values(),
+            key=lambda tok: tok.name
+        )
+
     def add_custom_tokens(self, custom_tokens, dont_overwrite=True):
         for custom_token in custom_tokens:
             token_name = custom_token.name.lower()

--- a/sept/token_manager.py
+++ b/sept/token_manager.py
@@ -17,10 +17,7 @@ class TokenManager(object):
     @property
     def tokens(self):
         # Don't include the NULL operator
-        return sorted(
-            self._cache.values(),
-            key=lambda tok: tok.name
-        )
+        return sorted(self._cache.values(), key=lambda tok: tok.name)
 
     def add_custom_tokens(self, custom_tokens, dont_overwrite=True):
         for custom_token in custom_tokens:

--- a/usage.py
+++ b/usage.py
@@ -1,3 +1,6 @@
+import os
+import webbrowser
+
 import six
 
 from sept import PathTemplateParser, Token, Operator
@@ -5,6 +8,9 @@ from sept import PathTemplateParser, Token, Operator
 
 # Custom Tokens
 class FirstNameToken(Token):
+    """
+    The <code>firstname</code> Token will return the "first_name" value from the user data dictionary.
+    """
     name = "firstname"
 
     def getValue(self, data):
@@ -12,6 +18,9 @@ class FirstNameToken(Token):
 
 
 class LastNameToken(Token):
+    """
+    The <code>lastname</code> Token will return the "last_name" value from the user data dictionary.
+    """
     name = "lastname"
 
     def getValue(self, data):
@@ -20,6 +29,12 @@ class LastNameToken(Token):
 
 # Custom Operator
 class FirstCharacterOperator(Operator):
+    """
+    The <code>firstletter</code> Operator allows you to return the first letter of the Token.
+    <br>
+    <br>Examples (name = "alex"):
+    <br>&emsp;<code>{{firstletter:name}}&nbsp;&nbsp;   -> "a"</code>
+    """
     name = "firstletter"
     DATA_TYPES = (six.text_type, six.binary_type)
 
@@ -73,3 +88,15 @@ resolved_path = template_obj.resolve(state_data)
 
 print(resolved_path)
 # /home/ahughes
+
+
+# Generate and launch documentation
+operator_docs = parser.operator_documentation()
+token_docs = parser.token_documentation()
+
+operator_docs += "<br><br><hr><br><br>" + token_docs
+documentation_path = os.path.join(os.path.dirname(__file__), "documentation.html")
+with open(documentation_path, "w") as fh:
+    fh.write(operator_docs)
+
+webbrowser.open(documentation_path)

--- a/usage.py
+++ b/usage.py
@@ -11,6 +11,7 @@ class FirstNameToken(Token):
     """
     The <code>firstname</code> Token will return the "first_name" value from the user data dictionary.
     """
+
     name = "firstname"
 
     def getValue(self, data):
@@ -21,6 +22,7 @@ class LastNameToken(Token):
     """
     The <code>lastname</code> Token will return the "last_name" value from the user data dictionary.
     """
+
     name = "lastname"
 
     def getValue(self, data):
@@ -35,6 +37,7 @@ class FirstCharacterOperator(Operator):
     <br>Examples (name = "alex"):
     <br>&emsp;<code>{{firstletter:name}}&nbsp;&nbsp;   -> "a"</code>
     """
+
     name = "firstletter"
     DATA_TYPES = (six.text_type, six.binary_type)
 


### PR DESCRIPTION
This PR introduces additional documentation features on your Tokens and Operators.  

For Token objects, we are just looking at your docstring and your existing "name" attribute.  


For Operator objects, we are also looking at the new "args" attribute.  
This attribute is a list of dicts with the structure: {"name": str, "description": str, "required": bool}  

The keys are:  
    - "name": Display name, can have spaces or whatever.
    - "description": A longer description of what your argmuent is and what it does.
    - "required": A bool flag to let the user know if your argument is optional.

The `PathTemplateParser` class now has `operator_documentation()` and `token_documentation()` methods
These will return the string html representation of the generated documentation.

You can see an example of generated documentation in `usage.py` or below in the gif  

  ![operator-docs](https://user-images.githubusercontent.com/704821/104088298-a96c3380-521a-11eb-9f78-ec6130af10bd.gif)
